### PR TITLE
Update zip dependency version to 8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ sha2 = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.9"
-zip = "7"
+zip = "8"
 
 [workspace]
 members = ["example"]


### PR DESCRIPTION
`zip v7` depends on `lzma-rust2 v0.15.3` which was giving me compile issues on Windows. Bumping to `zip v8` resolves these issues with seemingly no issues.