### PR TITLE
Allow custom Theme types

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,23 +66,24 @@ Finally, it will generate a type-safe `iced` API that lets you use the font. In 
 // Do not edit manually.
 // d24460a00249b2acd0ccc64c3176452c546ad12d1038974e974d7bdb4cdb4a8f
 use iced::widget::{text, Text};
+use iced::widget::text::Catalog;
 use iced::Font;
 
 pub const FONT: &[u8] = include_bytes!("../fonts/example-icons.ttf");
 
-pub fn edit<'a>() -> Text<'a> {
+pub fn edit<'a, Theme: Catalog + 'a>() -> Text<'a, Theme> {
     icon("\u{270E}")
 }
 
-pub fn save<'a>() -> Text<'a> {
+pub fn save<'a, Theme: Catalog + 'a>() -> Text<'a, Theme> {
     icon("\u{1F4BE}")
 }
 
-pub fn trash<'a>() -> Text<'a> {
+pub fn trash<'a, Theme: Catalog + 'a>() -> Text<'a, Theme> {
     icon("\u{E10A}")
 }
 
-fn icon<'a>(codepoint: &'a str) -> Text<'a> {
+fn icon<'a, Theme: Catalog + 'a>(codepoint: &'a str) -> Text<'a, Theme> {
     text(codepoint).font(Font::with_name("example-icons"))
 }
 ```

--- a/example/src/icon.rs
+++ b/example/src/icon.rs
@@ -3,21 +3,22 @@
 // d24460a00249b2acd0ccc64c3176452c546ad12d1038974e974d7bdb4cdb4a8f
 use iced::Font;
 use iced::widget::{Text, text};
+use iced::widget::text::Catalog;
 
 pub const FONT: &[u8] = include_bytes!("../fonts/example-icons.ttf");
 
-pub fn edit<'a>() -> Text<'a> {
+pub fn edit<'a, Theme: Catalog + 'a>() -> Text<'a, Theme> {
     icon("\u{270E}")
 }
 
-pub fn save<'a>() -> Text<'a> {
+pub fn save<'a, Theme: Catalog + 'a>() -> Text<'a, Theme> {
     icon("\u{1F4BE}")
 }
 
-pub fn trash<'a>() -> Text<'a> {
+pub fn trash<'a, Theme: Catalog + 'a>() -> Text<'a, Theme> {
     icon("\u{E10A}")
 }
 
-fn icon(codepoint: &str) -> Text<'_> {
+fn icon<'a, Theme: Catalog + 'a>(codepoint: &'a str) -> Text<'a, Theme> {
     text(codepoint).font(Font::with_name("example-icons"))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,8 @@ pub fn build(path: impl AsRef<Path>) -> Result<(), Error> {
          // Do not edit manually. Source: {source}\n\
          // {hash}\n\
          use iced::Font;\n\
-         use iced::widget::{{Text, text}};\n\n\
+         use iced::widget::{{Text, text}};\n\
+         use iced::widget::text::Catalog;\n\n\
          pub const FONT: &[u8] = include_bytes!(\"{path}\");\n\n",
         source = relative_path.join(path.with_extension("toml")).display(),
         path = relative_path.join(path.with_extension("ttf")).display()
@@ -291,7 +292,7 @@ pub fn build(path: impl AsRef<Path>) -> Result<(), Error> {
     for (name, glyph) in glyphs {
         module.push_str(&format!(
             "\
-pub fn {name}<'a>() -> Text<'a> {{
+pub fn {name}<'a, Theme: Catalog + 'a>() -> Text<'a, Theme> {{
     icon(\"\\u{{{code:X}}}\")
 }}\n\n",
             code = glyph.code
@@ -300,7 +301,7 @@ pub fn {name}<'a>() -> Text<'a> {{
 
     module.push_str(&format!(
         "\
-fn icon(codepoint: &str) -> Text<'_> {{
+fn icon<'a, Theme: Catalog + 'a>(codepoint: &'a str) -> Text<'a, Theme> {{
     text(codepoint).font(Font::with_name(\"{file_name}\"))
 }}\n"
     ));


### PR DESCRIPTION
Adds a `Theme` generic to allow custom theme types.

I would have liked to add support for a custom `Renderer` as well, but that would require users to have the `advanced` feature on for their `iced` dependency - If anyone has a good idea how to do this without too much friction for the user, i'd like to see that as well, if possible :+1: 